### PR TITLE
Run application from /current folder

### DIFF
--- a/src/Squirrel/UpdateManager.ApplyReleases.cs
+++ b/src/Squirrel/UpdateManager.ApplyReleases.cs
@@ -370,6 +370,13 @@ namespace Squirrel
             async Task invokePostInstall(SemanticVersion currentVersion, bool isInitialInstall, bool firstRunOnly, bool silentInstall)
             {
                 var targetDir = getDirectoryForRelease(currentVersion);
+
+                if (isInitialInstall) {
+                    var currentDir = CopyToCurrent(targetDir);
+                    if (currentDir != null)
+                        targetDir = currentDir;
+                }
+
                 var args = isInitialInstall ?
                     String.Format("--squirrel-install {0}", currentVersion) :
                     String.Format("--squirrel-updated {0}", currentVersion);
@@ -413,6 +420,43 @@ namespace Squirrel
                 squirrelApps
                     .Select(exe => new ProcessStartInfo(exe, firstRunParam) { WorkingDirectory = Path.GetDirectoryName(exe) })
                     .ForEach(info => Process.Start(info));
+            }
+
+            public DirectoryInfo CopyToCurrent(DirectoryInfo appDir)
+            {
+                var currentDir = Path.Combine(appDir.Parent.FullName, "current");
+
+                if (appDir.Exists)
+                {
+                    try
+                    {
+                        this.Log().Info(String.Format("Moving {0} directory to current", appDir.Name));
+                        if (Directory.Exists(currentDir))
+                        {
+                            try
+                            {
+                                Utility.EmptyDirectory(currentDir);
+                            } catch(Exception e)
+                            {
+                                this.Log().Info("Failed to empty current directory, will try to override files");
+                            }
+                        }
+                        else
+                        {
+                            Directory.CreateDirectory(currentDir);
+                        }
+                        Utility.CopyDirectory(appDir, new DirectoryInfo(currentDir));
+                    }
+                    catch (Exception e)
+                    {
+                        this.Log().InfoException("Failed to move files to current directory", e);
+                    }
+                }
+                if (!Directory.Exists(currentDir))
+                {
+                    return null;
+                }
+                return new DirectoryInfo(currentDir);
             }
 
             void fixPinnedExecutables(SemanticVersion newCurrentVersion, bool removeAll = false)
@@ -593,9 +637,9 @@ namespace Squirrel
                     .Where(x => x.Name.ToLowerInvariant().Contains("app-"))
                     .Where(x => x.Name != currentVersionFolder && x.Name != originalVersionFolder);
 
-                // Get the current process list in an attempt to not burn 
+                // Get the current process list in an attempt to not burn
                 // directories which have running processes
-                var runningProcesses = UnsafeUtility.EnumerateProcesses(); 
+                var runningProcesses = UnsafeUtility.EnumerateProcesses();
 
                 // Finally, clean up the app-X.Y.Z directories
                 await toCleanup.ForEachAsync(async x => {

--- a/src/StubExecutable/StubExecutable.cpp
+++ b/src/StubExecutable/StubExecutable.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-wchar_t* FindRootAppDir() 
+wchar_t* FindRootAppDir()
 {
 	wchar_t* ourDirectory = new wchar_t[MAX_PATH];
 
@@ -24,7 +24,7 @@ wchar_t* FindRootAppDir()
 	return ourDirectory;
 }
 
-wchar_t* FindOwnExecutableName() 
+wchar_t* FindOwnExecutableName()
 {
 	wchar_t* ourDirectory = new wchar_t[MAX_PATH];
 
@@ -40,10 +40,23 @@ wchar_t* FindOwnExecutableName()
 	return ret;
 }
 
-std::wstring FindLatestAppDir() 
+std::wstring FindLatestAppDir(std::wstring appName)
 {
 	std::wstring ourDir;
 	ourDir.assign(FindRootAppDir());
+
+	//If current exists, just use that
+	std::wstring currDir, currFile;
+	currDir.assign(FindRootAppDir());
+	currDir += L"\\current";
+	currFile = currDir + L"\\" + appName;;
+
+	WIN32_FIND_DATA currInfo = { 0 };
+	HANDLE currFileHandle = FindFirstFile(currFile.c_str(), &currInfo);
+	if (currFileHandle != INVALID_HANDLE_VALUE) {
+		FindClose(currFileHandle);
+		return currDir.c_str();
+	}
 
 	ourDir += L"\\app-*";
 
@@ -93,8 +106,12 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	std::wstring appName;
 	appName.assign(FindOwnExecutableName());
 
-	std::wstring workingDir(FindLatestAppDir());
+	std::wstring workingDir(FindLatestAppDir(appName));
 	std::wstring fullPath(workingDir + L"\\" + appName);
+
+	std::wstring updateFile;
+	updateFile.assign(FindRootAppDir());
+	updateFile += L"\\Update.exe";
 
 	STARTUPINFO si = { 0 };
 	PROCESS_INFORMATION pi = { 0 };
@@ -104,9 +121,12 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	si.wShowWindow = nCmdShow;
 
 	std::wstring cmdLine(L"\"");
-	cmdLine += fullPath;
-	cmdLine += L"\" ";
+	cmdLine += updateFile;
+	cmdLine += L"\" --processStart ";
+	cmdLine += appName;
+	cmdLine += L" -a=\"";
 	cmdLine += lpCmdLine;
+	cmdLine += L"\"";
 
 	wchar_t* lpCommandLine = wcsdup(cmdLine.c_str());
 	wchar_t* lpCurrentDirectory = wcsdup(workingDir.c_str());

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -610,14 +610,82 @@ namespace Squirrel.Update
                 throw new ArgumentException();
             }
 
-            if (shouldWait) waitForParentToExit();
+             this.Log().Info("Waiting for parent to exit");
+             if (shouldWait) waitForParentToExit();
+             this.Log().Info("parent has exited");
+             try {
+                 var currentExe = RunFromCurrent(exeName, appDir, targetExe);
+                 if (currentExe != null) {
+                     targetExe = currentExe;
+                 }
 
-            try {
                 this.Log().Info("About to launch: '{0}': {1}", targetExe.FullName, arguments ?? "");
                 Process.Start(new ProcessStartInfo(targetExe.FullName, arguments ?? "") { WorkingDirectory = Path.GetDirectoryName(targetExe.FullName) });
             } catch (Exception ex) {
                 this.Log().ErrorException("Failed to start process", ex);
             }
+        }
+
+        public FileInfo RunFromCurrent(string exeName, string appDir, FileInfo targetExe )
+        {
+            var currentDir = Path.Combine(appDir, "current");
+            FileInfo currentExe = new FileInfo(Path.Combine(currentDir, exeName.Replace("%20", " ")));
+
+            try
+            {
+                bool copyToCurrent = false;
+                if(currentExe.Exists)
+                {
+                    var currentVersion = FileVersionInfo.GetVersionInfo(currentExe.FullName);
+                    var targetVersion = FileVersionInfo.GetVersionInfo(targetExe.FullName);
+
+                    this.Log().Info("Current directory app version:" + currentVersion.FileVersion);
+                    if (currentVersion.FileVersion != targetVersion.FileVersion)
+                    {
+                        copyToCurrent = true;
+                    }
+                }
+                else
+                {
+                    copyToCurrent = true;
+                }
+
+                if(copyToCurrent)
+                {
+                    this.Log().Info("Copying target to current");
+                    try {
+                        Utility.EmptyDirectory(currentDir);
+                    }
+                    catch (Exception e)
+                    {
+                        this.Log().Info("Failed to empty current directory, will try to override files");
+                    }
+                    Utility.CopyDirectory(new DirectoryInfo(targetExe.Directory.FullName), new DirectoryInfo(currentDir));
+                }
+            } catch(Exception e)
+            {
+                this.Log().InfoException("Failed to move current directory", e);
+            }
+
+            if (!Directory.Exists(currentDir))
+            {
+                return null;
+            }
+
+            this.Log().Info("Want to launch '{0}'", currentExe);
+
+            // Check for path canonicalization attacks
+            if (!currentExe.FullName.StartsWith(appDir, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            if (!currentExe.Exists)
+            {
+                this.Log().Error("File {0} doesn't exist in current release", currentExe);
+                return null;
+            }
+            return currentExe;
         }
 
         public void ShowHelp()


### PR DESCRIPTION
Squirrel.windows update.exe will always install the new update to a version specific folder. This causes issues with firewall rules as the path to `Zinc.exe` executable will change after every update, and user is prompted with a warning. NBN users don't have don't have admin permissions so ther cannot whitelist the app after autoupdate.

Issue with more details:
https://github.com/cotap/zinctop/issues/255

This PR modifies squirrel.windows, and the application will now install and run from `/current` folder

<img width="631" alt="Screen Shot 2020-08-27 at 3 17 56 PM" src="https://user-images.githubusercontent.com/74364/91501225-0d98e700-e87a-11ea-8f8b-82472776d085.png">

The logic itself doesn't change much, as Squirrel will always download and extract the update to new folder, and during the restart the .exe file will figure out the latest binary. In this case its `/current` instead of the latest version number.

How it works is that the code clears the /current during the update and copies over the latest version. If you set up a firewall rule for `/current/Zinc.exe`, Windows will treat the app as whitelisted.

During the first installation, the app is also installed to `/current`

The code is resiliant, so if it can't run the app from `/current', it'll fall back to the previous version folder, which is still present.

Here is an example where I just quit the app, and renamed the `/current` folder to `/X_current` and started AlphaZinc again - the app was able to re-create the `/current` directory with the Zinc executable, and started the app from the correct whitelisted location (file info opened from the task manager running processes list)

<img width="579" alt="Screen Shot 2020-08-27 at 3 23 24 PM" src="https://user-images.githubusercontent.com/74364/91501856-6ae16800-e87b-11ea-9063-015f95bc101f.png">

Note that in this example `update.exe` also downloaded a new update (like squirrel does normally) to a new folder and the extra folders will get destroyed during next update/restart.

This solution has to be built and provided for `electron-builder-squirrrel` and `electron-builder` so it won't pull in the original binaries from `electron-builder-binaries` repo (I need to document that in zinctop repo). But even if that would accidentally happen it won't necessarely break anything as this this change would be compatible with the normal version of squirrel.windows. We can just release a new build with this fix if someone accidentally releases a build with wrong `update.exe`.

Note that user would get this version right away, if they do a fresh installation - If they get this via the updater, they have to first get this updated code to their computer via auto updater (first release), and only the next release after that would be running the modified `update.exe` 